### PR TITLE
Adds dict command registration.

### DIFF
--- a/cleo/application.py
+++ b/cleo/application.py
@@ -208,12 +208,15 @@ class Application(object):
 
         If a command with the same name already exists, it will be overridden.
 
-        @param command: A Command object
-        @type command: Command
+        @param command: A Command object or a dictionary defining the command
+        @type command: Command or dict
 
         @return: The registered command
         @rtype: Command
         """
+        if isinstance(command, dict):
+            command = Command.from_dict(command)
+
         command.set_application(self)
 
         if not command.is_enabled():

--- a/cleo/commands/command.py
+++ b/cleo/commands/command.py
@@ -172,8 +172,22 @@ class Command(object):
 
         return self
 
+    def add_argument_from_dict(self, argument_dict):
+        argument = InputArgument.from_dict(argument_dict)
+
+        self._definition.add_argument(argument)
+
+        return self
+
     def add_option(self, name, shortcut=None, mode=None, description='', default=None):
         self._definition.add_option(InputOption(name, shortcut, mode, description, default))
+
+        return self
+
+    def add_option_from_dict(self, option_dict):
+        option = InputOption.from_dict(option_dict)
+
+        self._definition.add_option(option)
 
         return self
 
@@ -263,3 +277,37 @@ class Command(object):
     def validate_name(self, name):
         if not re.match('^[^:]+(:[^:]+)*$', name):
             raise CommandError('Command name "%s" is invalid.' % name)
+
+    @classmethod
+    def from_dict(cls, command_dict):
+        """
+        Creates a command from a dictionary.
+
+        @param command_dict: The dictionary defining the commmand
+        @type command_dict: dict
+
+        @return: The command
+        @rtype: Command
+        """
+        if len(command_dict) > 1:
+            raise Exception('Only one command can be defined (%d given).'
+                            % len(command_dict))
+
+        name = list(command_dict.keys())[0]
+        command = Command(name)
+
+        command_dict = command_dict[name]
+
+        if 'description' in command_dict:
+            command.set_description(command_dict['description'])
+
+        if 'aliases' in command_dict:
+            command.set_aliases(command_dict['aliases'])
+
+        for argument in command_dict.get('arguments', []):
+            command.add_argument_from_dict(argument)
+
+        for option in command_dict.get('options', []):
+            command.add_option_from_dict(option)
+
+        return command

--- a/cleo/inputs/input_argument.py
+++ b/cleo/inputs/input_argument.py
@@ -24,7 +24,7 @@ class InputArgument(object):
         @type default: mixed
         """
         if mode is None:
-            mode = self.__class__.OPTIONAL
+            mode = self.OPTIONAL
         elif not isinstance(mode, int) or mode > 7 or mode < 1:
             raise Exception('Argument mode "%s" is not valid.' % mode)
 
@@ -96,3 +96,31 @@ class InputArgument(object):
         @rtype: str
         """
         return self.__description
+
+    @classmethod
+    def from_dict(cls, argument_dict):
+        """
+        Created a InputArgument instance from a dictionary.
+
+        @param argument_dict: The dictionary defining the argument
+        @type argument_dict: dict
+
+        @return: The created InputArgument instance
+        @rtype: InputArgument
+        """
+        if len(argument_dict) > 1:
+            raise Exception('Only one argument can be defined (%d given).'
+                            % len(argument_dict))
+
+        name = list(argument_dict.keys())[0]
+
+        argument_dict = argument_dict[name]
+        description = argument_dict.get('description')
+        default = argument_dict.get('default')
+        required = argument_dict.get('required', False)
+        mode = cls.REQUIRED if required else cls.OPTIONAL
+
+        if argument_dict.get('list', False):
+            mode |= cls.IS_LIST
+
+        return cls(name, mode, description, default)

--- a/cleo/inputs/input_option.py
+++ b/cleo/inputs/input_option.py
@@ -157,3 +157,37 @@ class InputOption(object):
             and option.is_list() == self.is_list()\
             and option.is_value_required() == self.is_value_required()\
             and option.is_value_optional() == self.is_value_optional()
+
+    @classmethod
+    def from_dict(cls, option_dict):
+        """
+        Created a InputOption instance from a dictionary.
+
+        @param option_dict: The dictionary defining the argument
+        @type option_dict: dict
+
+        @return: The created InputOption instance
+        @rtype: InputOption
+        """
+        if len(option_dict) > 1:
+            raise Exception('Only one option can be defined (%d given).'
+                            % len(option_dict))
+
+        name = list(option_dict.keys())[0]
+
+        option_dict = option_dict[name]
+        description = option_dict.get('description')
+        shortcut = option_dict.get('shortcut')
+        default = option_dict.get('default')
+        value_required = option_dict.get('value_required')
+        if value_required is True:
+            mode = cls.VALUE_REQUIRED
+        elif value_required is False:
+            mode = cls.VALUE_OPTIONAL
+        else:
+            mode = cls.VALUE_NONE
+
+        if mode != cls.VALUE_NONE and option_dict.get('list', False):
+            mode |= cls.VALUE_IS_LIST
+
+        return cls(name, shortcut, mode, description, default)

--- a/tests/commands/test_command.py
+++ b/tests/commands/test_command.py
@@ -75,6 +75,16 @@ class CommandTest(CleoTestCase):
         self.assertEqual(ret, command)
         self.assertTrue(command.get_definition().has_argument('foo'))
 
+    def test_add_argument_from_dict(self):
+        """
+        Command.add_argument_from_dict() adds an argument to command.
+        """
+        command = TestCommand()
+        ret = command.add_argument_from_dict({'foo': {}})
+
+        self.assertEqual(ret, command)
+        self.assertTrue(command.get_definition().has_argument('foo'))
+
     def test_add_option(self):
         """
         Command.add_option() adds an option to command.
@@ -306,6 +316,38 @@ class CommandTest(CleoTestCase):
             self.open_fixture('command_astext.txt'),
             command.as_text()
         )
+
+    def test_from_dict(self):
+        command_dict = {
+            'foo': {
+                'description': 'The foo command.',
+                'aliases': ['foobar'],
+                'help': 'This is help.',
+                'arguments': [{
+                    'bar': {
+                        'description': 'The bar argument.',
+                        'required': True,
+                        'list': True
+                    }
+                }],
+                'options': [{
+                    'baz': {
+                        'shortcut': 'b',
+                        'description': 'The baz option.',
+                        'value_required': False,
+                        'list': True,
+                        'default': ['default']
+                    }
+                }]
+            }
+        }
+
+        command = Command.from_dict(command_dict)
+
+        self.assertTrue(isinstance(command, Command))
+        self.assertEqual('foo', command.get_name())
+        self.assertTrue(command.get_definition().has_argument('bar'))
+        self.assertTrue(command.get_definition().has_option('baz'))
 
     def callable_method(self, input_, output_):
         output_.writeln('from the code...')

--- a/tests/fixtures/foo_command.py
+++ b/tests/fixtures/foo_command.py
@@ -18,3 +18,16 @@ class FooCommand(Command):
         self.output = output_
 
         output_.writeln('called')
+
+
+def foo_code(input_, output_):
+    output_.writeln('called')
+
+
+foo_commmand = {
+    'foo:bar1': {
+        'description': 'The foo:bar command',
+        'aliases': ['afoobar'],
+        'code': foo_code
+    }
+}

--- a/tests/inputs/test_input_argument.py
+++ b/tests/inputs/test_input_argument.py
@@ -72,3 +72,24 @@ class InputArgumentTest(TestCase):
 
         argument = InputArgument('foo', InputArgument.REQUIRED)
         self.assertRaises(Exception, argument.set_default, 'default')
+
+    def test_from_dict(self):
+        """
+        InputArgument.from_dict() returns an InputArgument instance given a dict.
+        """
+        argument_dict = {
+            'foo': {
+                'description': 'The foo argument.',
+                'required': False,
+                'list': True,
+                'default': ['default']
+            }
+        }
+
+        argument = InputArgument.from_dict(argument_dict)
+        self.assertTrue(InputArgument, argument)
+        self.assertEqual('foo', argument.get_name())
+        self.assertEqual('The foo argument.', argument.get_description())
+        self.assertEqual(['default'], argument.get_default())
+        self.assertTrue(argument.is_list())
+        self.assertFalse(argument.is_required())

--- a/tests/inputs/test_input_option.py
+++ b/tests/inputs/test_input_option.py
@@ -106,3 +106,46 @@ class InputOptionTest(TestCase):
 
         option = InputOption('foo', 'f', InputOption.VALUE_NONE)
         self.assertRaises(Exception, option.set_default, 'default')
+
+    def test_from_dict(self):
+        """
+        InputOption.from_dict() returns an InputOption instance given a dict.
+        """
+        option_dict = {
+            'foo': {
+                'shortcut': 'f',
+                'description': 'The foo option.',
+                'value_required': False,
+                'list': True,
+                'default': ['default']
+            }
+        }
+
+        option = InputOption.from_dict(option_dict)
+        self.assertTrue(InputOption, option)
+        self.assertEqual('foo', option.get_name())
+        self.assertEqual('f', option.get_shortcut())
+        self.assertEqual('The foo option.', option.get_description())
+        self.assertEqual(['default'], option.get_default())
+        self.assertTrue(option.is_list())
+        self.assertFalse(option.is_value_required())
+        self.assertTrue(option.is_value_optional())
+
+        option_dict = {
+            'foo': {
+                'value_required': True
+            }
+        }
+
+        option = InputOption.from_dict(option_dict)
+        self.assertFalse(option.is_list())
+        self.assertTrue(option.is_value_required())
+
+        option_dict = {
+            'foo': {}
+        }
+
+        option = InputOption.from_dict(option_dict)
+        self.assertFalse(option.is_list())
+        self.assertFalse(option.is_value_required())
+        self.assertFalse(option.is_value_optional())

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -10,7 +10,7 @@ from cleo.testers.application_tester import ApplicationTester
 from cleo.helpers import HelperSet, FormatterHelper
 
 from . import CleoTestCase
-from .fixtures.foo_command import FooCommand
+from .fixtures.foo_command import FooCommand, foo_commmand
 from .fixtures.foo1_command import Foo1Command
 from .fixtures.foo2_command import Foo2Command
 from .fixtures.foo3_command import Foo3Command
@@ -163,6 +163,16 @@ class ApplicationTest(CleoTestCase):
             application.add,
             Foo5Command()
         )
+
+    def test_add_with_dictionary(self):
+        """
+        Application.add() accepts a dictionary as argument.
+        """
+        application = Application()
+
+        foo = application.add(foo_commmand)
+        self.assertTrue(isinstance(foo, Command))
+        self.assertEqual('foo:bar1', foo.get_name())
 
     def test_has_get(self):
         """


### PR DESCRIPTION
Closes #2 

Commands can now be registered by dictionaries.

``` python
from cleo import Application

def say_hello(input_, output_):
    name = input_.get_argument('name')
    uppercase = input_.get_option('uppercase')

    if uppercase:
        name = name.upper()

    output_.writeln('Hello %s' % name)

hello_command = {
    'hello': {
        'description': 'The hello command',
        'arguments': [{
            'name': {
                'description': 'The name',
                'required': True
            }
        }],
        'options': [{
            'uppercase': {
                'shortcut': 'u',
                'description': 'Uppercase the name',
                'value_required': None
            }
        }]
    }
}

application = Application()
application.add(hello_command)
```
