### PR TITLE
Use OrderedDict backport in case of Python2.6 or earlier

### DIFF
--- a/cleo/formatters/output_formatter_style.py
+++ b/cleo/formatters/output_formatter_style.py
@@ -1,6 +1,10 @@
 # -*- coding: utf-8 -*-
 
-from collections import OrderedDict
+try:
+    from collections import OrderedDict
+except ImportError:
+    # python 2.6 or earlier, use backport
+    from ordereddict import OrderedDict
 
 
 class OutputFormatterStyle(object):

--- a/cleo/inputs/input_definition.py
+++ b/cleo/inputs/input_definition.py
@@ -5,7 +5,11 @@ try:
 except ImportError:
     import json
 
-from collections import OrderedDict
+try:
+    from collections import OrderedDict
+except ImportError:
+    # python 2.6 or earlier, use backport
+    from ordereddict import OrderedDict
 
 from .input_option import InputOption
 


### PR DESCRIPTION
collections.OrderedDict was added in python 2.7.

This PR allows to use the backport for Python 2.6 : 
https://pypi.python.org/pypi/ordereddict