### PR TITLE
Fix #41: Added list of exclude values for tests in the `find_packages…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     author_email='sebastien.eustace@gmail.com',
     url='https://github.com/SDisPater/cleo',
     download_url='https://github.com/SDisPater/cleo/archive/v%s.tar.gz' % __version__,
-    packages=find_packages(),
+    packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
     install_requires=['nose', 'pylev', 'mock'],
     tests_require=['nose', 'mock'],
     test_suite='nose.collector',


### PR DESCRIPTION
**This fixes #41.** Added list of exclude values for tests in the `find_packages. 

The list includes : 
 - `"*.tests"`
 - `"*.tests.*"`
 - `"tests.*"`
 - `"tests"`

See the [Using find packages](https://pythonhosted.org/setuptools/setuptools.html#using-find-packages)
for more info. 