### PR TITLE
#37: Fills progress bar on finish

### DIFF
--- a/cleo/helpers/progress_helper.py
+++ b/cleo/helpers/progress_helper.py
@@ -190,8 +190,9 @@ class ProgressHelper(Helper):
         if self.start_time is None:
             raise Exception('You must start the progress bar before calling finish().')
 
+        self.bar_char = self.bar_char_original
+
         if not self.max_steps:
-            self.bar_char = self.bar_char_original
             self.display(True)
 
         self.start_time = None


### PR DESCRIPTION
**Fixes #37** This attempts to fill the progress bar after the `finish()` method is called for the progress bar. 