### PR TITLE
Release 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## [0.8.0] - 2020-03-26
+
+### Added
+
+- Errors are now rendered in a nicer way for Python 3.6+.
+
+
 ## [0.7.6] - 2019-10-25
 
 ### Fixed
@@ -212,7 +219,8 @@ This is a major release with some API changes.
 
 
 
-[Unreleased]: https://github.com/sdispater/cleo/compare/0.7.6...master
+[Unreleased]: https://github.com/sdispater/cleo/compare/0.8.0...master
+[0.8.0]: https://github.com/sdispater/cleo/releases/tag/0.8.0
 [0.7.6]: https://github.com/sdispater/cleo/releases/tag/0.7.6
 [0.7.5]: https://github.com/sdispater/cleo/releases/tag/0.7.5
 [0.7.4]: https://github.com/sdispater/cleo/releases/tag/0.7.4

--- a/cleo/__init__.py
+++ b/cleo/__init__.py
@@ -6,4 +6,4 @@ from .helpers import argument, option
 from .testers import ApplicationTester, CommandTester
 
 
-__version__ = "0.7.6"
+__version__ = "0.8.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cleo"
-version = "0.7.6"
+version = "0.8.0"
 description = "Cleo allows you to create beautiful and testable command-line interfaces."
 authors = [
     "Sébastien Eustace <sebastien@eustace.io>"


### PR DESCRIPTION
### Added

- Errors are now rendered in a nicer way for Python 3.6+.