### PR TITLE
Declare 'coms' and 'opts' as local in zsh completion template

### DIFF
--- a/cleo/commands/completions/templates.py
+++ b/cleo/commands/completions/templates.py
@@ -54,7 +54,7 @@ ZSH_TEMPLATE = """#compdef %(script_name)s
 
 %(function)s()
 {
-    local state com cur
+    local com coms cur opts state
 
     cur=${words[${#words[@]}]}
 


### PR DESCRIPTION
Prior to this change, zsh completion would break if either 'coms' or 'opts' were defined elsewhere globally.

Fixes #85 