### PR TITLE
Fix argv input reconstruction for namespace commands

### DIFF
--- a/cleo/application.py
+++ b/cleo/application.py
@@ -388,7 +388,10 @@ class Application:
             # If the command is namespaced we rearrange
             # the input to parse it as a single argument
             if isinstance(io.input, ArgvInput):
-                argv = sys.argv[:]
+                argv = io._input._tokens[:]
+
+                if io.input.script_name is not None:
+                    argv.insert(0, io.input.script_name)
 
                 namespace = name.split(" ")[0]
                 index = None
@@ -401,7 +404,7 @@ class Application:
                 if index is not None:
                     del argv[index + 1 : index + 1 + (len(name.split(" ")) - 1)]
 
-                io.set_input(ArgvInput(argv, definition=io.input._definition))
+                io.set_input(ArgvInput(argv))
 
         exit_code = self._run_command(command, io)
         self._running_command = None

--- a/tests/testers/test_application_tester.py
+++ b/tests/testers/test_application_tester.py
@@ -2,25 +2,56 @@ import pytest
 
 from cleo.application import Application
 from cleo.commands.command import Command
+from cleo.helpers import argument
+from cleo.helpers import option
 from cleo.testers.application_tester import ApplicationTester
 
 
 class FooCommand(Command):
     """
     Foo command
-
-    foo
-        {foo : Foo argument}
     """
+
+    name = "foo"
+
+    description = "Foo command"
+
+    arguments = [argument("foo")]
+
+    options = [option("--bar")]
 
     def handle(self):
         self.line(self.argument("foo"))
+
+        if self.option("bar"):
+            self.line("--bar activated")
+
+
+class FooBarCommand(Command):
+    """
+    Foo Bar command
+    """
+
+    name = "foo bar"
+
+    description = "Foo Bar command"
+
+    arguments = [argument("foo")]
+
+    options = [option("--baz")]
+
+    def handle(self):
+        self.line(self.argument("foo"))
+
+        if self.option("baz"):
+            self.line("--baz activated")
 
 
 @pytest.fixture()
 def app():
     app = Application()
     app.add(FooCommand())
+    app.add(FooBarCommand())
 
     return app
 
@@ -30,7 +61,14 @@ def tester(app):
     return ApplicationTester(app)
 
 
-def test_execute(tester):
-    assert 0 == tester.execute("foo bar")
+def test_execute(tester: ApplicationTester):
+    assert 0 == tester.execute("foo baz --bar")
     assert 0 == tester.status_code
-    assert "bar\n" == tester.io.fetch_output()
+    assert "baz\n--bar activated\n" == tester.io.fetch_output()
+
+
+def test_execute_namespace_command(tester: ApplicationTester):
+    tester.application.catch_exceptions(False)
+    assert 0 == tester.execute("foo bar baz --baz")
+    assert 0 == tester.status_code
+    assert "baz\n--baz activated\n" == tester.io.fetch_output()


### PR DESCRIPTION
`sys.argv` was always used even if the input was a `StringInput` instance.

This PR fixes the issue by retrieving the input's tokens instead.