### PR TITLE
fix: table style side effects

### DIFF
--- a/cleo/ui/table.py
+++ b/cleo/ui/table.py
@@ -2,6 +2,8 @@ import itertools
 import math
 import re
 
+from copy import deepcopy
+
 from typing import Dict
 from typing import Generator
 from typing import List
@@ -707,6 +709,6 @@ class Table:
             return name
 
         if name in cls._styles:
-            return cls._styles[name]
+            return deepcopy(cls._styles[name])
 
         raise ValueError(f'Table style "{name}" is not defined.')

--- a/tests/ui/test_table.py
+++ b/tests/ui/test_table.py
@@ -444,3 +444,30 @@ def test_column_style(io):
 """
 
     assert io.fetch_output() == expected
+
+
+def test_style_for_side_effects(io):
+    headers = ["Type", "Class", "Name"]
+    rows = [
+        ["GSV", "Range", "Bora Horza Gobuchul"],
+        ["GSV", "Plate", "Sleeper Service"],
+        ["GCU", "Ridge", "Grey Area"],
+        ["PS", "Abominator", "Falling Outside the Normal Moral Constraints"],
+    ]
+
+    table1 = Table(io)
+    table1.set_headers(headers)
+    table1.set_rows(rows)
+    table1.style.set_vertical_border_chars("x", "y")
+    table1.render()
+
+    output1 = io.fetch_output()
+
+    table2 = Table(io)
+    table2.set_headers(headers)
+    table2.set_rows(rows)
+    table2.render()
+
+    output2 = io.fetch_output()
+
+    assert output1 != output2


### PR DESCRIPTION
Spooky action at a distance was possible, thanks to each table style
serving as a global singleton. To resolve this, we return a copy every
time the user modifies the style.

A regression test is included. While it does not explicitly cover more
complex cases like altering the preset, asking for another, and then
asking for the original (which should be unaltered), it should suffice
to guard against this behavior.
