### PR TITLE
Quote commands in bash completion

### DIFF
--- a/cleo/commands/completions_command.py
+++ b/cleo/commands/completions_command.py
@@ -175,7 +175,7 @@ script. Consult your shells documentation for how to add such directives.
             options = [self._zsh_describe(opt, None).strip('"') for opt in options]
 
             desc = [
-                "            ({})".format(command),
+                '            ("{}")'.format(command),
                 '            opts="${{opts}} {}"'.format(" ".join(options)),
                 "            ;;",
             ]

--- a/tests/commands/completion/fixtures/bash.txt
+++ b/tests/commands/completion/fixtures/bash.txt
@@ -25,19 +25,19 @@ _my_function()
 
         case "$com" in
 
-            (command:with:colons)
+            ("command:with:colons")
             opts="${opts} --goodbye"
             ;;
 
-            (hello)
+            ("hello")
             opts="${opts} --dangerous-option --option-without-description"
             ;;
 
-            (help)
+            ("help")
             opts="${opts} "
             ;;
 
-            (list)
+            ("list")
             opts="${opts} "
             ;;
 


### PR DESCRIPTION
This fixes the following errors reported in python-poetry/poetry#4572 when sourcing the Poetry (version 1.2.0a2) bash completion (`poetry completions bash`):

```bash
bash: eval: line 301: syntax error near unexpected token `clear'
bash: eval: line 301: `            (cache clear)'
```

