### PR TITLE
fix: resolve namespaced sub-commands in help command

### DIFF
--- a/news/258.bugfix.md
+++ b/news/258.bugfix.md
@@ -1,0 +1,1 @@
+Fixed the built-in `help` command failing to resolve namespaced sub-commands passed as separate tokens.

--- a/src/cleo/commands/help_command.py
+++ b/src/cleo/commands/help_command.py
@@ -15,8 +15,9 @@ class HelpCommand(Command):
         Argument(
             "command_name",
             required=False,
+            is_list=True,
             description="The command name",
-            default="help",
+            default=["help"],
         )
     ]
 
@@ -43,7 +44,10 @@ To display the list of available commands, please use the <info>list</info> comm
 
         if self._command is None:
             assert self._application is not None
-            self._command = self._application.find(self.argument("command_name"))
+            command_name = self.argument("command_name")
+            if isinstance(command_name, list):
+                command_name = " ".join(command_name)
+            self._command = self._application.find(command_name)
 
         self.line("")
         TextDescriptor().describe(self._io, self._command)

--- a/tests/fixtures/application_run5.txt
+++ b/tests/fixtures/application_run5.txt
@@ -3,10 +3,10 @@ Description:
   Displays help for a command.
 
 Usage:
-  help [options] [--] [<command_name>]
+  help [options] [--] [<command_name>...]
 
 Arguments:
-  command_name          The command name [default: "help"]
+  command_name          The command name [default: ["help"]]
 
 Options:
   -h, --help            Display help for the given command. When no command is given display help for the list command.

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -346,6 +346,15 @@ def test_run_with_help(tester: ApplicationTester) -> None:
     ).read_text(encoding="utf-8")
 
 
+def test_run_help_command_with_namespaced_command(app: Application) -> None:
+    app.catch_exceptions(False)
+    app.add(FooSubNamespaced1Command())
+    tester = ApplicationTester(app)
+
+    assert tester.execute("help foo bar baz", decorated=False) == 0
+    assert "The foo bar baz command" in tester.io.fetch_output()
+
+
 def test_run_with_input() -> None:
     app = Application()
     command = Foo3Command()


### PR DESCRIPTION
The `help` command only read the first token of the command name, so `app help foo bar` failed for namespaced commands while `app help "foo bar"` worked. This makes `command_name` a list argument and joins the tokens before lookup, mirroring how namespaced commands are parsed during normal invocation.

Closes #258