### PR TITLE
docs: use correct import paths in examples

### DIFF
--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -6,7 +6,7 @@ create ``greet_command.py`` and add the following to it:
 
 .. code-block:: python
 
-    from cleo import Command
+    from cleo.commands.command import Command
 
 
     class GreetCommand(Command):
@@ -40,7 +40,7 @@ an ``Application`` and adds commands to it:
     #!/usr/bin/env python
 
     from greet_command import GreetCommand
-    from cleo import Application
+    from cleo.application import Application
 
     application = Application()
     application.add(GreetCommand())
@@ -406,7 +406,7 @@ console:
 
     import pytest
 
-    from cleo import Application
+    from cleo.application import Application
     from cleo.testers.command_tester import CommandTester
 
     def test_execute(self):
@@ -430,7 +430,7 @@ as a string to the ``CommandTester.execute()`` method:
 
     import pytest
 
-    from cleo import Application
+    from cleo.application import Application
     from cleo.testers.command_tester import CommandTester
 
     def test_execute(self):

--- a/docs/single_command_tool.rst
+++ b/docs/single_command_tool.rst
@@ -7,7 +7,7 @@ it is possible to remove this need by using `default()` when adding a command:
 
 .. code-block:: python
 
-    from cleo import Application
+    from cleo.application import Application
 
     command = GreetCommand()
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -14,7 +14,7 @@ built-in options as well as a couple of built-in commands for Cleo.
         #!/usr/bin/env python
         # application.py
 
-        from cleo import Application
+        from cleo.application import Application
 
         application = Application()
         # ...

--- a/news/531.docs.md
+++ b/news/531.docs.md
@@ -1,0 +1,1 @@
+Fixed import paths in documentation examples to match the public API.


### PR DESCRIPTION
The documentation examples import `Application` and `Command` from the top-level `cleo` package (`from cleo import Application`, `from cleo import Command`), but `cleo/__init__.py` only exposes `__version__`, so these examples raise `ImportError` when run.

This updates the examples in `introduction.rst`, `usage.rst`, and `single_command_tool.rst` to use the canonical paths already used in the README and tests:

- `from cleo.application import Application`
- `from cleo.commands.command import Command`