### PR TITLE
fix: propagate input stream in Command.call() for interactive questions

### DIFF
--- a/news/333.bugfix.md
+++ b/news/333.bugfix.md
@@ -1,0 +1,1 @@
+Propagated the parent command input stream when calling commands with interactive questions.

--- a/src/cleo/commands/command.py
+++ b/src/cleo/commands/command.py
@@ -92,8 +92,11 @@ class Command:
         assert self.application is not None
         command = self.application.get(name)
 
+        string_input = StringInput(args or "")
+        string_input.set_stream(self._io.input.stream)
+
         return self.application._run_command(
-            command, self._io.with_input(StringInput(args or ""))
+            command, self._io.with_input(string_input)
         )
 
     def call_silent(self, name: str, args: str | None = None) -> int:

--- a/src/cleo/commands/command.py
+++ b/src/cleo/commands/command.py
@@ -95,9 +95,7 @@ class Command:
         string_input = StringInput(args or "")
         string_input.set_stream(self._io.input.stream)
 
-        return self.application._run_command(
-            command, self._io.with_input(string_input)
-        )
+        return self.application._run_command(command, self._io.with_input(string_input))
 
     def call_silent(self, name: str, args: str | None = None) -> int:
         """

--- a/tests/commands/test_command.py
+++ b/tests/commands/test_command.py
@@ -87,3 +87,46 @@ def test_explicit_multiple_argument() -> None:
     tester.execute("1 2 3")
 
     assert tester.io.fetch_output() == "1,2,3\n"
+
+
+def test_call_propagates_stream_for_confirm() -> None:
+    """call() must propagate the parent's input stream so that interactive
+    questions (confirm, ask, …) in the callee can read from it.
+
+    Regression test for https://github.com/python-poetry/cleo/issues/333.
+    """
+
+    class GreetedCommand(Command):
+        name = "greeted"
+        description = "Greeted command"
+        arguments: ClassVar = [argument("name", "Name to greet")]
+
+        def handle(self) -> int:
+            name = self.argument("name")
+            confirmed = self.confirm(f"Say hello to {name}?")
+            if confirmed:
+                self.line(f"Hello, {name}!")
+            return 0
+
+    class GreeterCommand(Command):
+        name = "greeter"
+        description = "Greeter command"
+        arguments: ClassVar = [argument("name", "Name to greet")]
+
+        def handle(self) -> int:
+            # The first positional of the args string is consumed by the app's
+            # implicit "command" argument in the merged definition, so a
+            # placeholder is required before the actual argument values.
+            self.call("greeted", f"greeted {self.argument('name')}")
+            return 0
+
+    app = Application()
+    app.add(GreeterCommand())
+    app.add(GreetedCommand())
+
+    from cleo.testers.application_tester import ApplicationTester
+
+    tester = ApplicationTester(app)
+    # Provide "yes" so that confirm() can read from the propagated stream.
+    tester.execute("greeter Alice", inputs="yes\n")
+    assert "Hello, Alice!" in tester.io.fetch_output()


### PR DESCRIPTION
## Problem

When a command uses `call()` to invoke another command that contains interactive questions (`confirm`, `ask`, `choice`), the callee crashes with:

```
AttributeError: 'NoneType' object has no attribute 'readline'
```

**Root cause:** `call()` constructs a fresh `StringInput` whose `_stream` defaults to `None`, but never copies the parent IO's stream. When the callee calls:

```
confirm() → Question.ask() → io.read_line() → input.read_line() → self._stream.readline()
```

`self._stream` is `None`, causing the crash.

## Fix

Propagate `self._io.input.stream` to the new `StringInput` before passing it to `_run_command`:

```python
string_input = StringInput(args or "")
string_input.set_stream(self._io.input.stream)
```

## Test

Added `test_call_propagates_stream_for_confirm` which exercises a caller→callee chain where the callee uses `confirm()`, providing `inputs="yes\n"` through `ApplicationTester`. Before this fix the test raises `AttributeError`; after it passes.

Fixes #333

---

This pull request was prepared with the assistance of AI, under my direction and review.