### PR TITLE
Render application help for bare help options

### DIFF
--- a/news/249.bugfix.md
+++ b/news/249.bugfix.md
@@ -1,0 +1,1 @@
+Rendered application help for bare ``--help`` and ``-h`` invocations instead of command help for the default command.

--- a/src/cleo/application.py
+++ b/src/cleo/application.py
@@ -365,10 +365,12 @@ class Application:
         name = self._get_command_name(io)
         if io.input.has_parameter_option(["--help", "-h"], True):
             if not name:
-                name = "help"
-                io.set_input(ArgvInput(["console", "help", self._default_command]))
-            else:
-                self._want_helps = True
+                from cleo.descriptors.text_descriptor import TextDescriptor
+
+                TextDescriptor().describe(io, self)
+
+                return 0
+            self._want_helps = True
 
         if not name:
             name = self._default_command
@@ -543,11 +545,7 @@ class Application:
                     "--help",
                     "-h",
                     flag=True,
-                    description=(
-                        "Display help for the given command. "
-                        "When no command is given display help for "
-                        f"the <info>{self._default_command}</info> command."
-                    ),
+                    description="Display this help message.",
                 ),
                 Option(
                     "--quiet", "-q", flag=True, description="Do not output any message."

--- a/tests/commands/completion/fixtures/fish.txt
+++ b/tests/commands/completion/fixtures/fish.txt
@@ -9,7 +9,7 @@ end
 
 # global options
 complete -c script -n '__fish_my_function_no_subcommand' -l ansi -d 'Force ANSI output.'
-complete -c script -n '__fish_my_function_no_subcommand' -l help -d 'Display help for the given command. When no command is given display help for the list command.'
+complete -c script -n '__fish_my_function_no_subcommand' -l help -d 'Display this help message.'
 complete -c script -n '__fish_my_function_no_subcommand' -l no-ansi -d 'Disable ANSI output.'
 complete -c script -n '__fish_my_function_no_subcommand' -l no-interaction -d 'Do not ask any interactive question.'
 complete -c script -n '__fish_my_function_no_subcommand' -l quiet -d 'Do not output any message.'

--- a/tests/commands/completion/fixtures/zsh.txt
+++ b/tests/commands/completion/fixtures/zsh.txt
@@ -18,7 +18,7 @@ _my_function()
 
     if [[ ${cur} == --* ]]; then
         state="option"
-        opts+=("--ansi:Force ANSI output." "--help:Display help for the given command. When no command is given display help for the list command." "--no-ansi:Disable ANSI output." "--no-interaction:Do not ask any interactive question." "--quiet:Do not output any message." "--verbose:Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug." "--version:Display this application version.")
+        opts+=("--ansi:Force ANSI output." "--help:Display this help message." "--no-ansi:Disable ANSI output." "--no-interaction:Do not ask any interactive question." "--quiet:Do not output any message." "--verbose:Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug." "--version:Display this application version.")
     elif [[ $cur == $com ]]; then
         state="command"
         coms+=("command\:with\:colons:Test." "hello:Complete me please." "help:Displays help for a command." "list:Lists commands." "'spaced command':Command with space in name.")

--- a/tests/fixtures/application_run1.txt
+++ b/tests/fixtures/application_run1.txt
@@ -4,7 +4,7 @@ Usage:
   command [options] [arguments]
 
 Options:
-  -h, --help            Display help for the given command. When no command is given display help for the list command.
+  -h, --help            Display this help message.
   -q, --quiet           Do not output any message.
   -V, --version         Display this application version.
       --ansi            Force ANSI output.

--- a/tests/fixtures/application_run2.txt
+++ b/tests/fixtures/application_run2.txt
@@ -1,15 +1,10 @@
-
-Description:
-  Lists commands.
+Console
 
 Usage:
-  list [options] [--] [<namespace>]
-
-Arguments:
-  namespace             The namespace name
+  command [options] [arguments]
 
 Options:
-  -h, --help            Display help for the given command. When no command is given display help for the list command.
+  -h, --help            Display this help message.
   -q, --quiet           Do not output any message.
   -V, --version         Display this application version.
       --ansi            Force ANSI output.
@@ -17,12 +12,6 @@ Options:
   -n, --no-interaction  Do not ask any interactive question.
   -v|vv|vvv, --verbose  Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug.
 
-Help:
-  The list command lists all commands:
-  
-    console list
-  
-  You can also display the commands for a specific namespace:
-  
-    console list test
-  
+Available commands:
+  help  Displays help for a command.
+  list  Lists commands.

--- a/tests/fixtures/application_run3.txt
+++ b/tests/fixtures/application_run3.txt
@@ -9,7 +9,7 @@ Arguments:
   namespace             The namespace name
 
 Options:
-  -h, --help            Display help for the given command. When no command is given display help for the list command.
+  -h, --help            Display this help message.
   -q, --quiet           Do not output any message.
   -V, --version         Display this application version.
       --ansi            Force ANSI output.

--- a/tests/fixtures/application_run5.txt
+++ b/tests/fixtures/application_run5.txt
@@ -9,7 +9,7 @@ Arguments:
   command_name          The command name [default: "help"]
 
 Options:
-  -h, --help            Display help for the given command. When no command is given display help for the list command.
+  -h, --help            Display this help message.
   -q, --quiet           Do not output any message.
   -V, --version         Display this application version.
       --ansi            Force ANSI output.


### PR DESCRIPTION
Fixes #249.

## Summary
- render application help for bare `--help` and `-h` invocations instead of command help for the default `list` command
- update the global help option description used in command/application help output
- refresh shell completion fixtures and add a news fragment

## Tests
- `PYTHONPATH=src python -m pytest tests\test_application.py tests\commands\completion\test_completions_command.py -q`
- `python -m ruff check src\cleo\application.py tests\test_application.py`
- `python -m ruff format --check src\cleo\application.py tests\test_application.py`
- `python -m towncrier check --compare-with origin/main`