### PR TITLE
Fix zsh completion for namespaced commands

### DIFF
--- a/news/153.bugfix.md
+++ b/news/153.bugfix.md
@@ -1,0 +1,1 @@
+Fixed zsh completions for namespaced commands so subcommands and subcommand options are suggested correctly.

--- a/src/cleo/commands/completions/templates.py
+++ b/src/cleo/commands/completions/templates.py
@@ -58,29 +58,35 @@ ZSH_TEMPLATE = """\
 %(function)s()
 {
     local state com cur
+    local -a command_words
     local -a opts
     local -a coms
 
-    cur=${words[${#words[@]}]}
+    cur=${words[$CURRENT]}
 
     # lookup for command
-    for word in ${words[@]:1}; do
+    for word in ${words[@]:1:$((CURRENT - 2))}; do
         if [[ $word != -* ]]; then
-            com=$word
-            break
+            command_words+=$word
         fi
     done
+    com=${(j: :)command_words}
 
     if [[ ${cur} == --* ]]; then
         state="option"
         opts+=(%(opts)s)
-    elif [[ $cur == $com ]]; then
+    else
         state="command"
-        coms+=(%(cmds)s)
     fi
 
     case $state in
         (command)
+            case "$com" in
+
+%(cmds)s
+
+            esac
+
             _describe 'command' coms
         ;;
         (option)

--- a/src/cleo/commands/completions_command.py
+++ b/src/cleo/commands/completions_command.py
@@ -229,20 +229,44 @@ script. Consult your shells documentation for how to add such directives.
         ]
 
         # Commands + options
-        cmds = []
+        cmds_by_prefix: dict[str, dict[str, str | None]] = {"": {}}
         cmds_opts = []
         for cmd in sorted(self.application.all().values(), key=lambda c: c.name or ""):
             if cmd.hidden or not (cmd.enabled and cmd.name):
                 continue
-            command_name = shell_quote(cmd.name) if " " in cmd.name else cmd.name
-            cmds.append(self._zsh_describe(command_name, sanitize(cmd.description)))
+            parts = cmd.name.split(" ")
+            prefix = ""
+            for idx, part in enumerate(parts):
+                cmds_by_prefix.setdefault(prefix, {})
+                description = (
+                    sanitize(cmd.description) if idx == len(parts) - 1 else None
+                )
+                existing = cmds_by_prefix[prefix].get(part)
+                if existing is None or description is not None:
+                    cmds_by_prefix[prefix][part] = description
+
+                prefix = f"{prefix} {part}".strip()
+
             options = " ".join(
                 self._zsh_describe(f"--{opt.name}", sanitize(opt.description))
                 for opt in sorted(cmd.definition.options, key=lambda o: o.name)
             )
             cmds_opts += [
-                f"            ({command_name})",
+                f'            ("{cmd.name}")',
                 f"            opts+=({options})",
+                "            ;;",
+                "",  # newline
+            ]
+
+        cmds = []
+        for prefix, entries in cmds_by_prefix.items():
+            descriptions = " ".join(
+                self._zsh_describe(name, description)
+                for name, description in sorted(entries.items())
+            )
+            cmds += [
+                f'            ("{prefix}")',
+                f"            coms+=({descriptions})",
                 "            ;;",
                 "",  # newline
             ]
@@ -251,7 +275,7 @@ script. Consult your shells documentation for how to add such directives.
             "script_name": script_name,
             "function": function,
             "opts": " ".join(opts),
-            "cmds": " ".join(cmds),
+            "cmds": "\n".join(cmds[:-1]),
             "cmds_opts": "\n".join(cmds_opts[:-1]),  # trim trailing newline
             "compdefs": "\n".join(f"compdef {function} {alias}" for alias in aliases),
         }

--- a/tests/commands/completion/fixtures/zsh.txt
+++ b/tests/commands/completion/fixtures/zsh.txt
@@ -3,51 +3,63 @@
 _my_function()
 {
     local state com cur
+    local -a command_words
     local -a opts
     local -a coms
 
-    cur=${words[${#words[@]}]}
+    cur=${words[$CURRENT]}
 
     # lookup for command
-    for word in ${words[@]:1}; do
+    for word in ${words[@]:1:$((CURRENT - 2))}; do
         if [[ $word != -* ]]; then
-            com=$word
-            break
+            command_words+=$word
         fi
     done
+    com=${(j: :)command_words}
 
     if [[ ${cur} == --* ]]; then
         state="option"
         opts+=("--ansi:Force ANSI output." "--help:Display help for the given command. When no command is given display help for the list command." "--no-ansi:Disable ANSI output." "--no-interaction:Do not ask any interactive question." "--quiet:Do not output any message." "--verbose:Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug." "--version:Display this application version.")
-    elif [[ $cur == $com ]]; then
+    else
         state="command"
-        coms+=("command\:with\:colons:Test." "hello:Complete me please." "help:Displays help for a command." "list:Lists commands." "'spaced command':Command with space in name.")
     fi
 
     case $state in
         (command)
+            case "$com" in
+
+            ("")
+            coms+=("command\:with\:colons:Test." "hello:Complete me please." "help:Displays help for a command." "list:Lists commands." "spaced")
+            ;;
+
+            ("spaced")
+            coms+=("command:Command with space in name.")
+            ;;
+
+            esac
+
             _describe 'command' coms
         ;;
         (option)
             case "$com" in
 
-            (command:with:colons)
+            ("command:with:colons")
             opts+=("--goodbye")
             ;;
 
-            (hello)
+            ("hello")
             opts+=("--dangerous-option:This \$hould be \`escaped\`." "--option-without-description")
             ;;
 
-            (help)
+            ("help")
             opts+=()
             ;;
 
-            (list)
+            ("list")
             opts+=()
             ;;
 
-            ('spaced command')
+            ("spaced command")
             opts+=("--goodbye")
             ;;
 

--- a/tests/commands/completion/test_completions_command.py
+++ b/tests/commands/completion/test_completions_command.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import subprocess
+
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -73,6 +75,62 @@ def test_zsh(mocker: MockerFixture) -> None:
     expected = (FIXTURES_PATH / "zsh.txt").read_text(encoding="utf-8")
 
     assert expected == tester.io.fetch_output().replace("\r\n", "\n")
+
+
+@pytest.mark.skipif(WINDOWS, reason="Only test linux shells")
+def test_zsh_handles_namespaced_commands(mocker: MockerFixture) -> None:
+    mocker.patch(
+        "cleo.io.inputs.string_input.StringInput.script_name",
+        new_callable=mocker.PropertyMock,
+        return_value="/path/to/my/script",
+    )
+    mocker.patch(
+        "cleo.commands.completions_command.CompletionsCommand._generate_function_name",
+        return_value="_my_function",
+    )
+
+    command = app.find("completions")
+    tester = CommandTester(command)
+    tester.execute("zsh")
+    script = tester.io.fetch_output().replace("\r\n", "\n")
+
+    probe = (
+        "setopt no_nomatch\n"
+        "compdef(){ :; }\n"
+        "_arguments(){ :; }\n"
+        "_describe(){\n"
+        "  local label=$1\n"
+        "  local array_name=$2\n"
+        "  local -a values\n"
+        '  values=("${(@P)array_name}")\n'
+        '  print -- "LABEL:$label"\n'
+        "  print -rl -- $values\n"
+        "}\n"
+        "words=(script '')\n"
+        "CURRENT=2\n"
+        f"{script}\n"
+        'print -- "--command-state--"\n'
+        "words=(script spaced '')\n"
+        "CURRENT=3\n"
+        "_my_function\n"
+        'print -- "--option-state--"\n'
+        "words=(script spaced command --g)\n"
+        "CURRENT=4\n"
+        "_my_function\n"
+    )
+    result = subprocess.run(
+        ["zsh", "-fc", probe],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+    assert (
+        "--command-state--\nLABEL:command\ncommand:Command with space in name.\n"
+        in result.stdout
+    )
+    assert "--option-state--\nLABEL:option\n" in result.stdout
+    assert result.stdout.rstrip().endswith("--goodbye")
 
 
 @pytest.mark.skipif(WINDOWS, reason="Only test linux shells")

--- a/tests/commands/completion/test_completions_command.py
+++ b/tests/commands/completion/test_completions_command.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import shutil
 import subprocess
 
 from pathlib import Path
@@ -19,6 +20,7 @@ if TYPE_CHECKING:
     from pytest_mock import MockerFixture
 
 FIXTURES_PATH = Path(__file__).parent / "fixtures"
+ZSH = shutil.which("zsh")
 
 
 app = Application()
@@ -94,6 +96,15 @@ def test_zsh_handles_namespaced_commands(mocker: MockerFixture) -> None:
     tester.execute("zsh")
     script = tester.io.fetch_output().replace("\r\n", "\n")
 
+    assert (
+        '            ("spaced")\n            coms+=("command:Command with space in name.")'
+        in script
+    )
+    assert '            ("spaced command")\n            opts+=("--goodbye")' in script
+
+    if ZSH is None:
+        return
+
     probe = (
         "setopt no_nomatch\n"
         "compdef(){ :; }\n"
@@ -119,10 +130,11 @@ def test_zsh_handles_namespaced_commands(mocker: MockerFixture) -> None:
         "_my_function\n"
     )
     result = subprocess.run(
-        ["zsh", "-fc", probe],
+        [ZSH, "-fc", probe],
         check=True,
         text=True,
         capture_output=True,
+        encoding="utf-8",
     )
 
     assert (


### PR DESCRIPTION
## Summary
- complete namespaced zsh commands one token at a time instead of inserting escaped spaces
- resolve command options using the full namespaced command path
- add a regression test and news fragment for the zsh completion behavior

Fixes #153

## Testing
- `uv run --python 3.12 --with pytest --with pytest-mock pytest tests/commands/completion/test_completions_command.py tests/commands/test_command.py -q`
- `uv run --python 3.12 --with ruff ruff check src/cleo/commands/completions_command.py src/cleo/commands/completions/templates.py tests/commands/completion/test_completions_command.py`
- `uv run --python 3.12 --with ruff ruff format --check src/cleo/commands/completions_command.py src/cleo/commands/completions/templates.py tests/commands/completion/test_completions_command.py`