### PR TITLE
Escape backslashes in fish completion descriptions

### DIFF
--- a/news/536.bugfix.md
+++ b/news/536.bugfix.md
@@ -1,0 +1,1 @@
+Escape backslashes in generated fish completion descriptions.

--- a/src/cleo/commands/completions_command.py
+++ b/src/cleo/commands/completions_command.py
@@ -261,7 +261,15 @@ script. Consult your shells documentation for how to add such directives.
         function = self._generate_function_name(script_name, script_path)
 
         def sanitize(s: str) -> str:
-            return self._io.output.formatter.remove_format(s).replace("'", "\\'")
+            # Descriptions are emitted inside single-quoted fish arguments
+            # (`-d '...'`). In fish, a backslash inside single quotes still
+            # escapes a following backslash or single quote, so it has to be
+            # escaped before the single quote is.
+            return (
+                self._io.output.formatter.remove_format(s)
+                .replace("\\", "\\\\")
+                .replace("'", "\\'")
+            )
 
         # Global options
         assert self.application

--- a/tests/commands/completion/test_completions_command.py
+++ b/tests/commands/completion/test_completions_command.py
@@ -7,6 +7,7 @@ import pytest
 
 from cleo._compat import WINDOWS
 from cleo.application import Application
+from cleo.commands.command import Command
 from cleo.testers.command_tester import CommandTester
 from tests.commands.completion.fixtures.command_with_colons import CommandWithColons
 from tests.commands.completion.fixtures.command_with_space_in_name import SpacedCommand
@@ -94,3 +95,33 @@ def test_fish(mocker: MockerFixture) -> None:
     expected = (FIXTURES_PATH / "fish.txt").read_text(encoding="utf-8")
 
     assert expected == tester.io.fetch_output().replace("\r\n", "\n")
+
+
+@pytest.mark.skipif(WINDOWS, reason="Only test linux shells")
+def test_fish_escapes_backslashes_in_descriptions(mocker: MockerFixture) -> None:
+    mocker.patch(
+        "cleo.io.inputs.string_input.StringInput.script_name",
+        new_callable=mocker.PropertyMock,
+        return_value="/path/to/my/script",
+    )
+    mocker.patch(
+        "cleo.commands.completions_command.CompletionsCommand._generate_function_name",
+        return_value="_my_function",
+    )
+
+    class BackslashCommand(Command):
+        name = "winpath"
+        description = "Use C:\\temp and it's fun"
+
+    local_app = Application()
+    local_app.add(BackslashCommand())
+
+    command = local_app.find("completions")
+    tester = CommandTester(command)
+    tester.execute("fish")
+    output = tester.io.fetch_output().replace("\r\n", "\n")
+
+    # The description is emitted inside `-d '...'`. A backslash inside fish
+    # single quotes still escapes the next character, so it must be doubled;
+    # otherwise the closing quote can be escaped and the script breaks.
+    assert "-d 'Use C:\\\\temp and it\\'s fun'" in output


### PR DESCRIPTION
The fish completions generator escapes single quotes in each option and command description, but leaves backslashes untouched:

```python
def sanitize(s: str) -> str:
    return self._io.output.formatter.remove_format(s).replace("'", "\'")
```

The result is emitted inside a single-quoted fish argument, `-d '<description>'`. Single quotes in fish are not fully literal: per the [language docs](https://fishshell.com/docs/current/language.html), "the only meaningful escape sequences in single quotes are `\'`, which escapes a single quote and `\`, which escapes the backslash symbol." So a backslash in a description is mishandled:

- a doubled backslash collapses to a single one, and
- a trailing backslash escapes the closing quote, which ends the string early and breaks the rest of the generated `complete` line.

The zsh path already accounts for this. `_zsh_describe` escapes backslashes (they are part of the character class it passes through `re.sub`), so the fish path is the odd one out.

The fix escapes backslashes before single quotes, matching the order zsh already uses:

```python
return (
    self._io.output.formatter.remove_format(s)
    .replace("\\", "\\\\")
    .replace("'", "\'")
)
```

I added a regression test that renders a fish completion for a command whose description contains a backslash and a single quote, and checks that both are escaped. Reverting the one-line change makes it fail. The full test suite passes and `ruff check`/`ruff format` are clean.
