### PR TITLE
Improve invalid subcommand errors

### DIFF
--- a/news/320.bugfix.md
+++ b/news/320.bugfix.md
@@ -1,0 +1,1 @@
+Improved the error message for invalid subcommands in a command namespace.

--- a/src/cleo/application.py
+++ b/src/cleo/application.py
@@ -595,6 +595,8 @@ class Application:
                 if self.has(candidate):
                     return candidate
 
+            return candidates[-1]
+
         return io.input.first_argument
 
     def extract_namespace(self, name: str, limit: int | None = None) -> str:

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -230,6 +230,18 @@ def test_set_catch_exceptions(app: Application, environ: dict[str, str]) -> None
         tester.execute("foo", decorated=False)
 
 
+def test_invalid_subcommand_uses_full_command_name(app: Application) -> None:
+    app.auto_exits(False)
+    app.catch_exceptions(True)
+    app.add(FooCommand())
+
+    tester = ApplicationTester(app)
+    tester.execute("foo baz", decorated=False)
+
+    assert tester.status_code == 1
+    assert 'The command "foo baz" does not exist.' in tester.io.fetch_error()
+
+
 def test_auto_exit(app: Application) -> None:
     app.auto_exits(False)
     assert not app.is_auto_exit_enabled()


### PR DESCRIPTION
Fixes #320.

When a command namespace is followed by an invalid subcommand, Cleo now reports the full attempted command instead of only the namespace.

For example, `foo baz` now reports that `foo baz` does not exist, rather than saying that `foo` does not exist.

Tested with:

```powershell
python -m pytest tests/test_application.py::test_invalid_subcommand_uses_full_command_name -q
python -m pytest tests/test_application.py -q
python -m ruff check src/cleo/application.py tests/test_application.py
```